### PR TITLE
提高易用性&bug修复

### DIFF
--- a/CloudFlare_DDNS_Setter.sh
+++ b/CloudFlare_DDNS_Setter.sh
@@ -71,6 +71,8 @@ choose_service(){
 			read -p "(input 1 or 2 to select):" service
 		done
 		[[ "${service}" = "1" ]] && get_record_id
+        sed -i '/CloudFlare_DDNS/d' /var/spool/cron/root
+        echo -e '*/3 * * * * bash CloudFlare_DDNS_Setter.sh --ddns' >> /var/spool/cron/root
 		[[ "${service}" = "2" ]] && create_record
 
 	elif [[ "$1" == "--ddns" ]]; then

--- a/CloudFlare_DDNS_Setter.sh
+++ b/CloudFlare_DDNS_Setter.sh
@@ -56,7 +56,7 @@ define(){
 	domain=`cat ${ddns_conf} | grep "domain" | awk -F "=" '{print $NF}'`
 	ttl=`cat ${ddns_conf} | grep "ttl" | awk -F "=" '{print $NF}'`
 
-	dynamic_ip=`curl curl ifconfig.me`
+	dynamic_ip=`curl ifconfig.me`
 }
 
 choose_service(){

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Script to set DDNS Record via [CloudFlare](https://www.cloudflare.com)
 ```bash
 mkdir /home/CloudFlare_DDNS
 cd /home/CloudFlare_DDNS
-wget https://raw.githubusercontent.com/nanqinlang-script/CloudFlare_DNS_Record/Setter/CloudFlare_DDNS_Setter.sh
-wget https://raw.githubusercontent.com/nanqinlang-script/CloudFlare_DNS_Record/Setter/config.conf
+wget https://raw.githubusercontent.com/dovela/CloudFlare_DNS_Record/Setter/CloudFlare_DDNS_Setter.sh
+wget https://raw.githubusercontent.com/dovela/CloudFlare_DNS_Record/Setter/config.conf
 ```
 
 ## config

--- a/config.conf
+++ b/config.conf
@@ -2,6 +2,5 @@ email=
 zone_id=
 api_key=
 
-record_id=
 domain=
 ttl=


### PR DESCRIPTION
经修改后，输上邮箱、api、zone_id、域名、ttl后，运行后，选1，可自动获取到record_id并填入config，再运行脚本--ddns即可，和原操作方法基本类似但简化。
添加定时任务ddns更新
同时有ipv4和ipv6时，curl ip.sb获取到的是ipv6地址，因此替换ip.sb为ifconfig.me
centos7测试通过