### PR TITLE
提高易用性&bug修复

### DIFF
--- a/CloudFlare_DDNS_Setter.sh
+++ b/CloudFlare_DDNS_Setter.sh
@@ -56,7 +56,7 @@ define(){
 	domain=`cat ${ddns_conf} | grep "domain" | awk -F "=" '{print $NF}'`
 	ttl=`cat ${ddns_conf} | grep "ttl" | awk -F "=" '{print $NF}'`
 
-	dynamic_ip=`curl ifconfig.me`
+	dynamic_ip=`curl ipv4.ip.sb`
 }
 
 choose_service(){

--- a/CloudFlare_DDNS_Setter.sh
+++ b/CloudFlare_DDNS_Setter.sh
@@ -11,7 +11,9 @@ echo -e "${Green_font}
 # Github: https://github.com/nanqinlang
 #=======================================
 # Secondary editing by dovela
-# Version: 2.1
+# Version: 2.1 beta
+# Github: https://github.com/dovela/CloudFlare_DNS_Record
+# If you find problems, plz submit issue
 #=======================================
 ${Font_suffix}"
 

--- a/CloudFlare_DDNS_Setter.sh
+++ b/CloudFlare_DDNS_Setter.sh
@@ -71,6 +71,8 @@ choose_service(){
 			read -p "(input 1 or 2 to select):" service
 		done
 		[[ "${service}" = "1" ]] && get_record_id
+        sed -i '/CloudFlare_DDNS/d' /var/spool/cron/root
+        echo -e '*/3 * * * * bash CloudFlare_DDNS_Setter.sh --ddns' >> /var/spool/cron/root
 		[[ "${service}" = "2" ]] && create_record
 
 	elif [[ "$1" == "--ddns" ]]; then

--- a/CloudFlare_DDNS_Setter.sh
+++ b/CloudFlare_DDNS_Setter.sh
@@ -56,7 +56,7 @@ define(){
 	domain=`cat ${ddns_conf} | grep "domain" | awk -F "=" '{print $NF}'`
 	ttl=`cat ${ddns_conf} | grep "ttl" | awk -F "=" '{print $NF}'`
 
-	dynamic_ip=`curl curl ifconfig.me`
+	dynamic_ip=`curl ifconfig.me`
 }
 
 choose_service(){

--- a/CloudFlare_DDNS_Setter.sh
+++ b/CloudFlare_DDNS_Setter.sh
@@ -162,7 +162,7 @@ Lightsail_conf(){
 
 lightsail_change_ip(){
     #检查本机ip是否被tcp阻断
-    tcp_status=`curl --silent https://ipcheck.need.sh/api_v2.php?ip=${local_ip}` | awk -F '[:}]' '{print $21}'
+    tcp_status=`curl --silent https://ipcheck.need.sh/api_v2.php?ip=${local_ip} | awk -F '[:}]' '{print $21}'`
     
     if [[ $tcp_status == "false" ]]; then
     # 删除现有静态IP

--- a/CloudFlare_DDNS_Setter.sh
+++ b/CloudFlare_DDNS_Setter.sh
@@ -11,7 +11,7 @@ echo -e "${Green_font}
 # Github: https://github.com/nanqinlang
 #=======================================
 # Secondary editing by dovela
-# Version: 1.0
+# Version: 1.1
 #=======================================
 ${Font_suffix}"
 
@@ -24,6 +24,13 @@ check_root(){
 
 check_system(){
 	[[ -z "`cat /etc/issue | grep -E -i "debian"`" && -z "`cat /etc/issue | grep -E -i "ubuntu"`" && -z "`cat /etc/redhat-release | grep -E -i "CentOS"`" ]] && echo -e "${Error} only support Debian or Ubuntu or CentOS !" && exit 1
+}
+
+check_ip_diff(){
+    remote_ip=`ping $domain -c 1 -W 1 | head -n 1 | awk '{print $3}' | sed 's/[()]//g'`
+    if [[ $remote_ip == $dynamic_ip ]]; then
+        exit 1
+    fi
 }
 
 check_deps(){
@@ -56,7 +63,7 @@ define(){
 	domain=`cat ${ddns_conf} | grep "domain" | awk -F "=" '{print $NF}'`
 	ttl=`cat ${ddns_conf} | grep "ttl" | awk -F "=" '{print $NF}'`
 
-	dynamic_ip=`curl ipv4.ip.sb`
+    dynamic_ip=`curl ipv4.ip.sb`
 }
 
 choose_service(){
@@ -76,6 +83,7 @@ choose_service(){
 		[[ "${service}" = "2" ]] && create_record
 
 	elif [[ "$1" == "--ddns" ]]; then
+        check_ip_diff
 		echo -e "${Info} now will start automatically ddns record updating service"
 		update_record
 

--- a/CloudFlare_DDNS_Setter.sh
+++ b/CloudFlare_DDNS_Setter.sh
@@ -78,17 +78,18 @@ choose_service(){
 	if [[ -z "$1" ]]; then
 		echo -e "${Info} if you want a automatic ddns, firstly you should get record_id"
 		echo -e "${Info} alternatively you can use this script to create a A record and get its id"
-		echo -e "${Info} now select required service:\n1.get domain record_id\n2.create a new domain A record"
-		read -p "(input 1 or 2 to select):" service
-		while [[ ! "${service}" =~ ^[1-2]$ ]]
+		echo -e "${Info} now select required service:\n1.get domain record_id\n2.create a new domain A record\n3.configure lightsail"
+		read -p "(input 1~3 to select):" service
+		while [[ ! "${service}" =~ ^[1-3]$ ]]
 		do
 			echo -e "${Error} invalid input !"
-			read -p "(input 1  or 2 to select):" service
+			read -p "(input 1~3 to select):" service
 		done
 		[[ "${service}" = "1" ]] && get_record_id
         sed -i '/CloudFlare_DDNS/d' /var/spool/cron/root
         echo -e '*/3 * * * * bash CloudFlare_DDNS_Setter.sh --ddns' >> /var/spool/cron/root
 		[[ "${service}" = "2" ]] && create_record
+        [[ "${service}" = "3" ]] && Lightsail_conf
 
 	elif [[ "$1" == "--ddns" ]]; then
         if [[ $lightsail_switich == true ]]; then
@@ -133,7 +134,7 @@ get_record_id(){
     echo -e "record_id=${record_id}" >> ${ddns_conf}
 }
 
-Lightsail_deps(){
+Lightsail_conf(){
     pip install awscli --upgrade
     clear
     echo -e '''

--- a/CloudFlare_DDNS_Setter.sh
+++ b/CloudFlare_DDNS_Setter.sh
@@ -59,19 +59,19 @@ directory(){
 define(){
 	[[ ! -f ${ddns_conf} ]] && echo -e "${Error} can not found config file, please check !" && exit 1
 
-	email=`cat ${ddns_conf} | grep "email" | awk -F "=" '{print $NF}'`
-	zone_id=`cat ${ddns_conf} | grep "zone_id" | awk -F "=" '{print $NF}'`
-	api_key=`cat ${ddns_conf} | grep "api_key" | awk -F "=" '{print $NF}'`
+	email=`cat ${ddns_conf} | grep "email" | awk -F "[ =]" '{print $2}'`
+	zone_id=`cat ${ddns_conf} | grep "zone_id" | awk -F "[ =]" '{print $2}'`
+	api_key=`cat ${ddns_conf} | grep "api_key" | awk -F "[ =]" '{print $2}'`
 
-	record_id=`cat ${ddns_conf} | grep "record_id" | awk -F "=" '{print $NF}'`
-	domain=`cat ${ddns_conf} | grep "domain" | awk -F "=" '{print $NF}'`
-	ttl=`cat ${ddns_conf} | grep "ttl" | awk -F "=" '{print $NF}'`
+	record_id=`cat ${ddns_conf} | grep "record_id" | awk -F "[ =]" '{print $2}'`
+	domain=`cat ${ddns_conf} | grep "domain" | awk -F "[ =]" '{print $2}'`
+	ttl=`cat ${ddns_conf} | grep "ttl" | awk -F "[ =]" '{print $2}'`
 
     local_ip=`curl ipv4.ip.sb`
     
-    lightsail_switich=`cat ${ddns_conf} | grep "lightsail_switich" | awk -F "=" '{print $NF}'`
-    lightsail_ipname=`cat ${ddns_conf} | grep "lightsail_ipname" | awk -F "=" '{print $NF}'`
-    lightsail_instance=`cat ${ddns_conf} | grep "lightsail_instance" | awk -F "=" '{print $NF}'`
+    lightsail_switich=`cat ${ddns_conf} | grep "lightsail_switich" | awk -F "[ =]" '{print $2}'`
+    lightsail_ipname=`cat ${ddns_conf} | grep "lightsail_ipname" | awk -F "[ =]" '{print $2}'`
+    lightsail_instance=`cat ${ddns_conf} | grep "lightsail_instance" | awk -F "[ =]" '{print $2}'`
 }
 
 choose_service(){

--- a/CloudFlare_DDNS_Setter.sh
+++ b/CloudFlare_DDNS_Setter.sh
@@ -78,7 +78,7 @@ choose_service(){
 	if [[ -z "$1" ]]; then
 		echo -e "${Info} if you want a automatic ddns, firstly you should get record_id"
 		echo -e "${Info} alternatively you can use this script to create a A record and get its id"
-		echo -e "${Info} now select required service:\n1.get domain record_id\n2.create a new domain A record\n3.configure lightsail"
+		echo -e "${Info} now select required service:\n1.get domain record_id\n2.create a new domain A record\n3.configure lightsail if necessary"
 		read -p "(input 1~3 to select):" service
 		while [[ ! "${service}" =~ ^[1-3]$ ]]
 		do
@@ -154,7 +154,7 @@ Lightsail_conf(){
           ap-south-1 印度
    ===============================
     '''
-    aws configure #输入AWSAccessKeyId和AWSSecretKey以及本机地域,第四项留空，Key由 https://console.aws.amazon.com/iam/home?region=us-east-2#/security_credential 申请
+    aws configure #输入AWSAccessKeyId和AWSSecretKey以及本机地域,第四项留空，Key由 https://console.aws.amazon.com/iam/home#/security_credential 申请
 }
 
 lightsail_change_ip(){
@@ -176,7 +176,7 @@ lightsail_change_ip(){
 
 check_root
 check_system
-[[ "$1" = "install" ]] && check_deps
+[[ "$1" = "install" ]] && check_deps && exit 0
 directory
 define
 choose_service $1

--- a/CloudFlare_DDNS_Setter.sh
+++ b/CloudFlare_DDNS_Setter.sh
@@ -168,12 +168,12 @@ lightsail_change_ip(){
     tcp_status=`curl --silent https://ipcheck.need.sh/api_v2.php?ip=${local_ip} | awk -F '[:}]' '{print $21}'`
     if [[ $tcp_status == "false" ]]; then
         tcp_count=0
-        while [[ $tcp_conut -lt $check_times ]]
+        while [[ $tcp_count -lt $check_times ]]
         do
             #如果false则多次检查确认,无true记录的话,更换ip,默认值4次
             tcp_status=`curl --silent https://ipcheck.need.sh/api_v2.php?ip=${local_ip} | awk -F '[:}]' '{print $21}'`
             [[ $tcp_status == "true" ]] && exit 0
-            tcp_conut=`expr ${tcp_conut} + 1`
+            tcp_count=`expr ${tcp_count} + 1`
             sleep 2s
         done
     # 删除现有静态IP

--- a/CloudFlare_DDNS_Setter.sh
+++ b/CloudFlare_DDNS_Setter.sh
@@ -92,7 +92,7 @@ choose_service(){
         [[ "${service}" = "3" ]] && Lightsail_conf
 
 	elif [[ "$1" == "--ddns" ]]; then
-        if [[ $lightsail_switich == true ]]; then
+        if [[ $lightsail_switich == "true" ]]; then
             lightsail_change_ip
         fi
         check_ip_diff
@@ -161,7 +161,7 @@ lightsail_change_ip(){
     #检查本机ip是否被tcp阻断
     tcp_status=`curl --silent https://ipcheck.need.sh/api_v2.php?ip=${local_ip}` | awk -F '[:}]' '{print $21}'
     
-    if [[ $tcp_status == false ]]; then
+    if [[ $tcp_status == "false" ]]; then
     # 删除现有静态IP
     aws lightsail release-static-ip --static-ip-name ${lightsail_ipname} >/dev/null 2>&1
     # 创建新IP

--- a/CloudFlare_DDNS_Setter.sh
+++ b/CloudFlare_DDNS_Setter.sh
@@ -176,7 +176,7 @@ lightsail_change_ip(){
 
 check_root
 check_system
-check_deps
+[[ "$1" = "install" ]] && check_deps
 directory
 define
 choose_service $1

--- a/CloudFlare_DDNS_Setter.sh
+++ b/CloudFlare_DDNS_Setter.sh
@@ -11,7 +11,7 @@ echo -e "${Green_font}
 # Github: https://github.com/nanqinlang
 #=======================================
 # Secondary editing by dovela
-# Version: 2.0
+# Version: 2.1
 #=======================================
 ${Font_suffix}"
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ ttl=
 # this id can be added automatically via "get domain record_id" selection in the script
 record_id=
 
+#"true" or "false",if local host is AWS' lightsail and you need replace ip automatically, please turn "true".
+lightsail_switich=false  
+
+#Created static ip's name of lightsail. Input anything you prefer.
+lightsail_ipname=
+
+#The name of the instance you already hold.It's like "CentOS-1GB-Tokyo-1"
+lightsail_instance=
 ```
 
 take a example, you should write like this:
@@ -52,6 +60,10 @@ api_key=84058228se28e28898b6ds3ej78yuf2136654
 
 domain=example.example.net
 ttl=120
+
+lightsail_switich=true  
+lightsail_ipname=ip-of-tokyo
+lightsail_instance=CentOS-1GB-Tokyo-1
 ```
 
 ## usage
@@ -63,8 +75,16 @@ write those config down:
 - api_key
 - domain
 - ttl
+- lightsail_switich (true or not）  
+- lightsail_ipname (if turn on)
+- lightsail_instance (if turn on)
 
 ### step 2
+if this is the first time the script is run
+```bash
+bash CloudFlare_DDNS_Setter.sh install
+```
+
 then run
 ```bash
 bash CloudFlare_DDNS_Setter.sh
@@ -77,6 +97,8 @@ this function will get the record_id of your domain and insert it into config fi
 2.**create new domain record**  
 this function can create a new A dns record
 
+3.***configure lightsail if necessary**
+this function is be used to configure AWS' access key and the location of local host
 
 ### step 3
 after you finished step 1~2, you will need to run this :
@@ -92,3 +114,9 @@ https://sometimesnaive.org/article/5 (to be updated)
 
 Cloudflare API documentation v4  
 https://api.cloudflare.com/#zone-properties
+
+AWS Documentation
+https://docs.aws.amazon.com/index.html#lang/en_us
+
+## notes
+*:you can get your AWSAccessKeyId and AWSSecretKey via [AWS Access keys](https://console.aws.amazon.com/iam/home#/security_credential). create new access key and save it.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ this script have already added a record that is `*/3 * * * * bash CloudFlare_DDN
 
 ## according
 中文文档  
-https://sometimesnaive.org/article/5 (to be updated)
+https://blog.mcgrady.site/?p=75
 
 Cloudflare API documentation v4  
 https://api.cloudflare.com/#zone-properties

--- a/README.md
+++ b/README.md
@@ -115,8 +115,14 @@ https://sometimesnaive.org/article/5 (to be updated)
 Cloudflare API documentation v4  
 https://api.cloudflare.com/#zone-properties
 
-AWS Documentation
+AWS Documentation  
 https://docs.aws.amazon.com/index.html#lang/en_us
+
+屌鸡tg@Unknow000 ipcheck service  
+https://ipcheck.need.sh/
+
+皮皮虾窝  
+https://ppxwo.com/dynamicip.ppx
 
 ## notes
 *:you can get your AWSAccessKeyId and AWSSecretKey via [AWS Access keys](https://console.aws.amazon.com/iam/home#/security_credential). create new access key and save it.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ Script to set DDNS Record via [CloudFlare](https://www.cloudflare.com)
 ## download
 ```bash
 mkdir /home/CloudFlare_DDNS
-cd /home/CloudFlare_DDNS
+wget https://raw.githubusercontent.com/dovela/CloudFlare_DNS_Record/Setter/config.conf /home/CloudFlare_DDNS
 wget https://raw.githubusercontent.com/dovela/CloudFlare_DNS_Record/Setter/CloudFlare_DDNS_Setter.sh
-wget https://raw.githubusercontent.com/dovela/CloudFlare_DNS_Record/Setter/config.conf
 ```
 
 ## config

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ domain=
 ttl=
 
 # the id of domain record you want to modify
-# you can't see it before run this script
+# you can't see it before ran this script
 # this id can be added automatically via "get domain record_id" selection in the script
 record_id=
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Script to set DDNS Record via [CloudFlare](https://www.cloudflare.com)
 ```bash
 mkdir /home/CloudFlare_DDNS
 cd /home/CloudFlare_DDNS
-wget https://raw.githubusercontent.com/nanqinlang-script/CloudFlare_DNS_Record/Setter/CloudFlare_DDNS_Setter.sh
-wget https://raw.githubusercontent.com/nanqinlang-script/CloudFlare_DNS_Record/Setter/config.conf
+wget https://raw.githubusercontent.com/dovela/CloudFlare_DNS_Record/Setter/CloudFlare_DDNS_Setter.sh
+wget https://raw.githubusercontent.com/dovela/CloudFlare_DNS_Record/Setter/config.conf
 ```
 
 ## config

--- a/README.md
+++ b/README.md
@@ -30,10 +30,6 @@ zone_id=
 # the api key of your cloudflare account
 api_key=
 
-# the id of domain record you want to modify
-# this id can be find via "get domain record_id" selection in the script
-record_id=
-
 # the domain you want to set
 domain=
 
@@ -41,6 +37,12 @@ domain=
 # min value:120
 # max value:2147483647
 ttl=
+
+# the id of domain record you want to modify
+# you can't see it before run this script
+# this id can be added automatically via "get domain record_id" selection in the script
+record_id=
+
 ```
 
 take a example, you should write like this:
@@ -49,7 +51,6 @@ email=example@gmail.com
 zone_id=3456dfdhfi465ff4ae263ef35esd060f
 api_key=84058228se28e28898b6ds3ej78yuf2136654
 
-record_id=1d3a9b54623334f3debc20c56eb5585c
 domain=example.example.net
 ttl=120
 ```
@@ -61,6 +62,8 @@ write those config down:
 - email
 - zone_id
 - api_key
+- domain
+- ttl
 
 ### step 2
 then run
@@ -70,24 +73,19 @@ bash CloudFlare_DDNS_Setter.sh
 and you will meet `select required service :`
 
 1.**get domain record_id**  
-this function will list all your dns records  
-you should get the id of a dns record from the list and write it down to `record_id` in the config file  
+this function will get the record_id of your domain and insert it into config file automatically
 
 2.**create new domain record**  
 this function can create a new A dns record
 
-### step 3
-continuously write those config down:
-- record_id
-- domain
-- ttl
 
-### step 4
-after you finished step 1~3, you will need to run this :
+### step 3
+after you finished step 1~2, you will need to run this :
 ```bash
 bash CloudFlare_DDNS_Setter.sh --ddns
 ```
 for above, the parameter `--ddns` is to update your dns A record to refresh your ddns. Freely let it automatically via such as `crontab`.
+this script have already added a record that is `*/3 * * * * bash CloudFlare_DDNS_Setter.sh --ddns` to `/var/spool/cron/root`,and you can use `crontab -e` to modify it.
 
 ## according
 中文文档  

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Script to set DDNS Record via [CloudFlare](https://www.cloudflare.com)
 ## download
 ```bash
 mkdir /home/CloudFlare_DDNS
-wget https://raw.githubusercontent.com/dovela/CloudFlare_DNS_Record/Setter/config.conf /home/CloudFlare_DDNS
+wget https://raw.githubusercontent.com/dovela/CloudFlare_DNS_Record/Setter/config.conf /home/CloudFlare_DDNS/config.conf
 wget https://raw.githubusercontent.com/dovela/CloudFlare_DNS_Record/Setter/CloudFlare_DDNS_Setter.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ this function will get the record_id of your domain and insert it into config fi
 2.**create new domain record**  
 this function can create a new A dns record
 
-3.***configure lightsail if necessary**
+3.***configure lightsail if necessary**  
 this function is be used to configure AWS' access key and the location of local host
 
 ### step 3

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Script to set DDNS Record via [CloudFlare](https://www.cloudflare.com)
 ## download
 ```bash
 mkdir /home/CloudFlare_DDNS
-wget https://raw.githubusercontent.com/dovela/CloudFlare_DNS_Record/Setter/config.conf /home/CloudFlare_DDNS/config.conf
+wget https://raw.githubusercontent.com/dovela/CloudFlare_DNS_Record/Setter/config.conf -O /home/CloudFlare_DDNS/config.conf
 wget https://raw.githubusercontent.com/dovela/CloudFlare_DNS_Record/Setter/CloudFlare_DDNS_Setter.sh
 ```
 

--- a/config.conf
+++ b/config.conf
@@ -5,6 +5,7 @@ api_key=
 domain=
 ttl=
 
-lightsail_switich=false
+lightsail_switich=false (default:false)
 lightsail_ipname=
 lightsail_instance=
+check_times=4 (default:4)

--- a/config.conf
+++ b/config.conf
@@ -2,6 +2,5 @@ email=
 zone_id=
 api_key=
 
-record_id=
 domain=
 ttl=

--- a/config.conf
+++ b/config.conf
@@ -5,6 +5,6 @@ api_key=
 domain=
 ttl=
 
-lightsail_switich=false
+lightsail_switch=false
 lightsail_ipname=
 lightsail_instance=

--- a/config.conf
+++ b/config.conf
@@ -4,3 +4,12 @@ api_key=
 
 domain=
 ttl=
+
+#"true" or "false",if local host is AWS' lightsail and you need replace ip automatically, please turn "true".
+lightsail_switich=false  
+
+#Created static ip's name of lightsail. Input anything you prefer.
+lightsail_ipname=
+
+#The name of the instance you already hold.It's like "CentOS-1GB-Tokyo-1"
+lightsail_instance=

--- a/config.conf
+++ b/config.conf
@@ -5,6 +5,6 @@ api_key=
 domain=
 ttl=
 
-lightsail_switich=false  
+lightsail_switich=false
 lightsail_ipname=
 lightsail_instance=

--- a/config.conf
+++ b/config.conf
@@ -5,11 +5,6 @@ api_key=
 domain=
 ttl=
 
-#"true" or "false",if local host is AWS' lightsail and you need replace ip automatically, please turn "true".
 lightsail_switich=false  
-
-#Created static ip's name of lightsail. Input anything you prefer.
 lightsail_ipname=
-
-#The name of the instance you already hold.It's like "CentOS-1GB-Tokyo-1"
 lightsail_instance=


### PR DESCRIPTION
经修改后，输上邮箱、api、zone_id、域名、ttl后，运行后，选1，可自动获取到record_id并填入config，再运行脚本--ddns即可，和原操作方法基本类似但简化。
添加定时任务ddns更新
同时有ipv4和ipv6时，curl ip.sb获取到的是ipv6地址，因此替换ip.sb为ifconfig.me
centos7测试通过